### PR TITLE
Revise information integrity goals

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,12 +243,15 @@ and does not imply that individual services on the web must therefore support al
 
 <section>
   <h3 id="verify" data-export="" data-dfn-type="dfn">
-The web must make it possible for people to verify the information they see
+The web should help people determine the trustworthiness of information
   </h3>
   <p>
-We have a responsibility to build web technologies to counter misinformation,
-allowing information sources to be traceable and facts to be checkable.
-The concept of origin and source is core to the web's security model.
+Society relies on the integrity of public information.
+As one of the most common ways people access information,
+the web must support the maintenance of public information for the public good,
+at least as well as previous information platforms.
+The public needs verifiable source and context information to recognize
+trustworthy web publishers and content.
 We will make sure the new web technologies we create
 do not work against this architectural principle.
   </p>

--- a/index.html
+++ b/index.html
@@ -248,7 +248,7 @@ The web should help people determine the trustworthiness of information
   <p>
 Society relies on the integrity of public information.
 As one of the most common ways people access information,
-the web must support the maintenance of public information for the public good,
+the web must support the maintenance of public information for the public good
 at least as well as previous information platforms.
 The public needs verifiable source and context information to recognize
 trustworthy web publishers and content.

--- a/index.html
+++ b/index.html
@@ -247,10 +247,10 @@ The web must make it possible for people to verify, and assess the trustworthine
   </h3>
   <p>
 Society relies on the integrity of public information.
-We have a responsibility to build web technologies to counter misinformation.
+We have a responsibility to build web technologies to counter misinformation, 
+and to maintain the integrity of information for public good.
 The public needs verifiable source and context information to recognize
 trustworthy web publishers and content.
-The web must support the maintenance of public information for the public good.
 The concept of origin and source is core to the web's security model.
 We will make sure the new web technologies we create
 do not work against this architectural principle.

--- a/index.html
+++ b/index.html
@@ -251,9 +251,7 @@ We have a responsibility to build web technologies to counter misinformation,
 and to maintain the integrity of information for public good.
 The public needs verifiable source and context information to recognize
 trustworthy web publishers and content.
-The concept of origin and source is core to the web's security model.
-We will make sure the new web technologies we create
-do not work against this architectural principle.
+The concepts of origin and source are core to the web's security model.
   </p>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -251,7 +251,7 @@ We have a responsibility to build web technologies to counter misinformation,
 and to maintain the integrity of information for public good.
 The public needs verifiable source and context information to recognize
 trustworthy web publishers and content.
-The concepts of [origin](https://html.spec.whatwg.org/multipage/browsers.html#origin) and [source](#transparent) are core to the web's security model.
+The concept of origin and [its relationship information sources](https://www.w3.org/2001/tag/doc/distributed-content/) are core to the web's security model.
   </p>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -248,9 +248,9 @@ The web must enable people to verify, and assess the trustworthiness of, informa
   <p>
 Society relies on the integrity of public information.
 We have a responsibility to build web technologies to counter misinformation.
-The web must support the maintenance of public information for the public good.
 The public needs verifiable source and context information to recognize
 trustworthy web publishers and content.
+The web must support the maintenance of public information for the public good.
 The concept of origin and source is core to the web's security model.
 We will make sure the new web technologies we create
 do not work against this architectural principle.

--- a/index.html
+++ b/index.html
@@ -243,7 +243,7 @@ and does not imply that individual services on the web must therefore support al
 
 <section>
   <h3 id="verify" data-export="" data-dfn-type="dfn">
-The web must enable people to verify, and assess the trustworthiness of, information.
+The web must make it possible for people to verify, and assess the trustworthiness of, information.
   </h3>
   <p>
 Society relies on the integrity of public information.

--- a/index.html
+++ b/index.html
@@ -243,15 +243,15 @@ and does not imply that individual services on the web must therefore support al
 
 <section>
   <h3 id="verify" data-export="" data-dfn-type="dfn">
-The web should help people determine the trustworthiness of information
+The web must enable people to verify, and assess the trustworthiness of, information.
   </h3>
   <p>
 Society relies on the integrity of public information.
-As one of the most common ways people access information,
-the web must support the maintenance of public information for the public good
-at least as well as previous information platforms.
+We have a responsibility to build web technologies to counter misinformation.
+The web must support the maintenance of public information for the public good.
 The public needs verifiable source and context information to recognize
 trustworthy web publishers and content.
+The concept of origin and source is core to the web's security model.
 We will make sure the new web technologies we create
 do not work against this architectural principle.
   </p>

--- a/index.html
+++ b/index.html
@@ -251,7 +251,7 @@ We have a responsibility to build web technologies to counter misinformation,
 and to maintain the integrity of information for public good.
 The public needs verifiable source and context information to recognize
 trustworthy web publishers and content.
-The concepts of origin and source are core to the web's security model.
+The concepts of [origin](https://html.spec.whatwg.org/multipage/browsers.html#origin) and [source](#transparent) are core to the web's security model.
   </p>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -243,7 +243,7 @@ and does not imply that individual services on the web must therefore support al
 
 <section>
   <h3 id="verify" data-export="" data-dfn-type="dfn">
-The web must make it possible for people to verify, and assess the trustworthiness of, information.
+The web must make it possible for people to verify information and assess the trustworthiness of its source.
   </h3>
   <p>
 Society relies on the integrity of public information.


### PR DESCRIPTION
Acknowledge the importance of public information, and the role of the web in maintaining public information for the public good. Update language to replace terms and concepts that may become stale over time, and recognize importance of context and user trust decisions.
