### PR TITLE
Align section title with grammar of others

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,7 +254,7 @@ and does not imply that individual services on the web must therefore support al
 
 <section>
   <h3 id="verify" data-export="" data-dfn-type="dfn">
-The web must make it possible for people to verify information and assess the trustworthiness of its source.
+The web makes it possible to verify information
   </h3>
   <p>
 Society relies on the integrity of public information.


### PR DESCRIPTION
I noticed thanks to #121 that I overlooked one of the section titles when we were making them consistent with each other a while back (#105). This PR fixes that.