### PR TITLE
correct people's possessive

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,11 +219,11 @@ and the platform should enable a fully accessible end-user experience.
 
 <section>
   <h3 id="privacy" data-export="" data-dfn-type="dfn">
-The web is secure, and respects peoples' privacy
+The web is secure, and respects people's privacy
   </h3>
   <p>
 When we add features to the web platform,
-we are making decisions that impact peoples'
+we are making decisions that impact people's
 ability to control their personal data.
 This data includes their conversations,
 their financial transactions
@@ -350,7 +350,7 @@ For example, people should be able to install style sheets,
 assistive browser extensions,
 and blockers of unwanted content or scripts.
 We will build features and write specifications
-that respect peoples' agency,
+that respect people's agency,
 and will create user agents to represent those preferences on the web user's behalf.
   </p>
 </section>


### PR DESCRIPTION
Quoting from a comment by Chris Needham:
>  In this context, "people's" is correct, as in, belonging to multiple individuals, whereas peoples' is the possessive of peoples (a grouping, culturally or nationally, etc). See https://www.britannica.com/dictionary/eb/qa/What-is-the-difference-between-people-and-peoples-