### PR TITLE
Switch [spec] authors to "editors" in the Purpose section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ and any power dynamics involved (see also the
 ### Purpose {#purpose}
 
 This is a statement of the ethical principles of the W3C community.
-Spec developers, editors, and reviewers can use it to guide their thinking.
+Spec contributors, editors, and reviewers can use it to guide their thinking.
 In particular, the purpose of this document is to
 inform wide review of new charters,
 new specifications, and

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ and any power dynamics involved (see also the
 ### Purpose {#purpose}
 
 This is a statement of the ethical principles of the W3C community.
-Spec developers, authors, and reviewers can use it to guide their thinking.
+Spec developers, editors, and reviewers can use it to guide their thinking.
 In particular, the purpose of this document is to
 inform wide review of new charters,
 new specifications, and


### PR DESCRIPTION
This is meant to fix #141. [Elsewhere](https://www.w3.org/TR/design-principles/#priority-of-constituencies) we use "authors" to refer to website authors, but that doesn't fit between spec developers and (presumably) spec reviewers.

Another option might be to remove this list item entirely: editors are either meant to apply the decisions of their working groups without needing to check the EWP, or they're acting as spec developers.

cc/ @lianqi