### PR TITLE
Clarify informing a broader scope of technical and community reports

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,9 +126,9 @@ and any power dynamics involved (see also the
 This is a statement of the ethical principles of the W3C community.
 Spec developers, authors, and reviewers can use it to guide their thinking.
 In particular, the purpose of this document is to
-inform wide review of new charters,
-new specifications, and
-updates to published recommendations.
+inform wide review of charters, and reports produced by the web community,
+including specifications, W3C recommendations, and other reports such as use
+cases and requirements.
 Others can read this document to understand how we are informing
 our design process with ethical considerations.
 


### PR DESCRIPTION
Clarifies that the Statement is not limited to "specifications" but extends to all W3C technical or community reports, and updates to those reports.